### PR TITLE
Fix expire overflow by using BigInteger

### DIFF
--- a/app/db/migrations/versions/9953c54cf26d_users_expire_bigint.py
+++ b/app/db/migrations/versions/9953c54cf26d_users_expire_bigint.py
@@ -1,0 +1,28 @@
+"""use BigInteger for expire columns
+
+Revision ID: 9953c54cf26d
+Revises: 2b231de97dc3
+Create Date: 2025-06-30 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '9953c54cf26d'
+down_revision = '2b231de97dc3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.alter_column('expire', type_=sa.BigInteger(), existing_type=sa.Integer(), nullable=True)
+    with op.batch_alter_table('next_plans') as batch_op:
+        batch_op.alter_column('expire', type_=sa.BigInteger(), existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.alter_column('expire', type_=sa.Integer(), existing_type=sa.BigInteger(), nullable=True)
+    with op.batch_alter_table('next_plans') as batch_op:
+        batch_op.alter_column('expire', type_=sa.Integer(), existing_type=sa.BigInteger(), nullable=True)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -75,7 +75,7 @@ class User(Base):
         default=UserDataLimitResetStrategy.no_reset,
     )
     usage_logs = relationship("UserUsageResetLogs", back_populates="user")  # maybe rename it to reset_usage_logs?
-    expire = Column(Integer, nullable=True)
+    expire = Column(BigInteger, nullable=True)
     admin_id = Column(Integer, ForeignKey("admins.id"))
     admin = relationship("Admin", back_populates="users")
     sub_revoked_at = Column(DateTime, nullable=True, default=None)
@@ -166,7 +166,7 @@ class NextPlan(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
     data_limit = Column(BigInteger, nullable=False)
-    expire = Column(Integer, nullable=True)
+    expire = Column(BigInteger, nullable=True)
     add_remaining_traffic = Column(Boolean, nullable=False, default=False, server_default='0')
     fire_on_either = Column(Boolean, nullable=False, default=True, server_default='0')
 


### PR DESCRIPTION
## Summary
- avoid out of range errors by storing expire timestamps as `BigInteger`
- add Alembic migration to update `users.expire` and `next_plans.expire`

## Testing
- `python -m py_compile app/db/models.py app/db/migrations/versions/9953c54cf26d_users_expire_bigint.py`


------
https://chatgpt.com/codex/tasks/task_b_686181320594832183179b1dfc76b73f